### PR TITLE
Ensure a non-success exit code is returned from "rake cypress:run"

### DIFF
--- a/exe/cypress-rails
+++ b/exe/cypress-rails
@@ -6,7 +6,7 @@ require Pathname.new(Dir.pwd).join("config/environment")
 require "cypress-rails"
 
 command = ARGV[0]
-case command
+result = case command
 when "init"
   CypressRails::Init.new.call
 when "open"
@@ -14,3 +14,6 @@ when "open"
 when "run"
   CypressRails::Run.new.call
 end
+
+exit 1 if !result
+exit 0

--- a/lib/cypress-rails/rake.rb
+++ b/lib/cypress-rails/rake.rb
@@ -13,5 +13,5 @@ end
 
 desc "Run Cypress tests headlessly"
 task :"cypress:run" do
-  system "#{CLI} run"
+  abort "Tests failed" unless system "#{CLI} run"
 end

--- a/lib/cypress-rails/version.rb
+++ b/lib/cypress-rails/version.rb
@@ -1,3 +1,3 @@
 module CypressRails
-  VERSION = "0.0.2"
+  VERSION = "0.0.3"
 end


### PR DESCRIPTION
# Problem

I found that when I ran "rake cypress:run" with failing tests, it would explain that it failed in the output to StdOut, but the actual exit code of the rake process would be 0 (success). You can find the exit code of the most recently run process using `echo $?`. This occurred for me on OSX Mojave using ZSH, but also occurred on Circle CI (linux / bash).

# Investigation

The implementation of CypressRails::Run is based on a call to `system`, which returns a boolean indicating whether the underlying call return a successful exit code. This call to cypress was failing, and returning a non-zero exit code, and so the call to system was returning false. The execution of `CypressRails::Run.new.call` was thus returning false.

However, while this was last command in exe/cypress-rails, this did not seem to cause a non-zero exit status (using ruby 2.6.2). 

# Solution

I've captured the result of this call, and I'm using it to manually call exit 1 or exit 0, which seems to do the trick.

I've also had to manually check this and do an abort in the rake task. Now I find that both calling `cypress-rails run` or `rake cypress:run` correctly returns either a 0 or 1 status code. This has been tested locally and on Circle CI. I've seen both failure and success work as expected. I've also used this as dependency inside another rake task, as I use a `rake ci` task to call this and other types of tests, and the abort works as expected.

I have not added any tests to this project as part of this fix.