### PR TITLE
Forward CLI options to cypress open and run commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,15 @@ Or, with rake:
 $ rake cypress:run
 ```
 
+### Pass options to cypress run or open
+
+Options can be provided to `cypress run` and `cypress open` using the 
+CYPRESS_OPTS environment variable
+
+```
+CYPRESS_OPTS="--record --key=abc123 --parallel" rake cypress:run
+```
+
 ### Write Ruby tests that wrap and invoke your cypress tests
 
 You can also extend a provided `CypressRails::TestCase`, which itself inherits

--- a/lib/cypress-rails/open.rb
+++ b/lib/cypress-rails/open.rb
@@ -8,12 +8,12 @@ module CypressRails
       @finds_bin = FindsBin.new
     end
 
-    def call(dir: Dir.pwd, port: ENV["RAILS_CYPRESS_PORT"])
+    def call(dir: Dir.pwd, port: ENV["RAILS_CYPRESS_PORT"], opts: ENV["CYPRESS_OPTS"])
       @starts_rails_server.call(dir: dir, port: port)
       bin = @finds_bin.call(dir)
 
       system <<~EXEC
-        CYPRESS_BASE_URL=http://#{Capybara.server_host}:#{Capybara.server_port} #{bin} open --project "#{dir}"
+        CYPRESS_BASE_URL=http://#{Capybara.server_host}:#{Capybara.server_port} #{bin} open --project "#{dir}" #{opts}
       EXEC
     end
   end

--- a/lib/cypress-rails/run.rb
+++ b/lib/cypress-rails/run.rb
@@ -8,12 +8,12 @@ module CypressRails
       @finds_bin = FindsBin.new
     end
 
-    def call(dir: Dir.pwd, port: ENV["RAILS_CYPRESS_PORT"])
+    def call(dir: Dir.pwd, port: ENV["RAILS_CYPRESS_PORT"], opts: ENV["CYPRESS_OPTS"])
       @starts_rails_server.call(dir: dir, port: port)
       bin = @finds_bin.call(dir)
 
       system <<~EXEC
-        CYPRESS_BASE_URL=http://#{Capybara.server_host}:#{Capybara.server_port} #{bin} run --project "#{dir}"
+        CYPRESS_BASE_URL=http://#{Capybara.server_host}:#{Capybara.server_port} #{bin} run --project "#{dir}" #{opts}
       EXEC
     end
   end

--- a/script/test_example_app
+++ b/script/test_example_app
@@ -8,4 +8,8 @@ cd example/an_app
 bundle
 yarn install
 bundle exec rake cypress:run
-bundle exec rake cypress:run --execute-print 'puts "test that includes passing cypress opts"'
+
+if ! CYPRESS_OPTS="-h" bundle exec rake cypress:run | grep -q "Usage: run \[options\]"; then
+  echo "Failed to pass options to cypress:run"
+  exit 1
+fi

--- a/script/test_example_app
+++ b/script/test_example_app
@@ -8,3 +8,4 @@ cd example/an_app
 bundle
 yarn install
 bundle exec rake cypress:run
+bundle exec rake cypress:run --execute-print 'puts "test that includes passing cypress opts"'

--- a/script/test_example_app
+++ b/script/test_example_app
@@ -7,9 +7,12 @@ directory=$1
 cd example/an_app
 bundle
 yarn install
-bundle exec rake cypress:run
 
+# test with options
 if ! CYPRESS_OPTS="-h" bundle exec rake cypress:run | grep -q "Usage: run \[options\]"; then
-  echo "Failed to pass options to cypress:run"
+  echo "Failed to pass options to cypress run"
   exit 1
 fi
+
+# test without options
+bundle exec rake cypress:run


### PR DESCRIPTION
Hi @searls ,

Thanks for building this gem. Our project it at the stage where we are want to run our tests in parallel so we'd like to pass additional options to cypress:run like `--record --key=abc123 --parallel`.

Cheers