### PR TITLE
Fix: Not running for dir with spaces

### DIFF
--- a/lib/cypress-rails/launches_cypress.rb
+++ b/lib/cypress-rails/launches_cypress.rb
@@ -28,7 +28,7 @@ module CypressRails
       set_exit_hooks!(config)
 
       system <<~EXEC
-        CYPRESS_BASE_URL=http://#{server.host}:#{server.port} #{bin} #{command} --project "#{config.dir}" #{config.cypress_cli_opts}
+        CYPRESS_BASE_URL=http://#{server.host}:#{server.port} "#{bin}" #{command} --project "#{config.dir}" #{config.cypress_cli_opts}
       EXEC
     end
 


### PR DESCRIPTION
Hi Justin

Thanks a lot for a great gem

We recently run into a small issue on one of our dev's machines and came up with the solution, so please feel free to review and include in a new version :)

**Issue**: After running `cypress-rails run`, Cypress could not be run locally if the project directory included any whitespace characters

**Solution**: Make sure the heredoc in `LaunchesCypress` class wraps the `bin` directory reference.

Best,
Adam