### PR TITLE
CI: Use Gemfile.lock version of bundler

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,7 @@ jobs:
       - type: cache-restore
         key: v1-main-{{ checksum "Gemfile.lock" }}
 
+      - run: gem install bundler --version `tail -1 Gemfile.lock`
       - run: bundle install --path vendor/bundle
 
       - type: cache-save


### PR DESCRIPTION
I'm not sure if this is the best fix for the problem.*

I couldn't find anything better searching online. Here are some proposed solutions:

https://gist.github.com/matthewrudy/734d7a951eb87fb1a80c3e49c6388d3e
https://discuss.circleci.com/t/you-must-use-bundler-2-or-greater-with-this-lockfile/30352
https://discuss.circleci.com/t/using-bundler-2-0-during-ci-fails/27411/3

Here's the passing build:
https://circleci.com/gh/vfonic/cypress-rails/3

*I'm sticking to bundler v1 in my projects