### PR TITLE
Add ability to specify host to StartRailsServer

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ preferred environment variables project-wide using a tool like
 
 
 * **CYPRESS_RAILS_DIR** (default: `Dir.pwd`) the directory of your project
+* **CYPRESS_RAILS_HOST** (default: 127.0.0.1) the hostname to bind to
 * **CYPRESS_RAILS_PORT** (default: _a random available port_) the port to run
   the Rails test server on
 * **CYPRESS_RAILS_BASE_PATH** (default: `"/"`) the base path for all Cypress's

--- a/lib/cypress-rails/config.rb
+++ b/lib/cypress-rails/config.rb
@@ -1,9 +1,10 @@
 require_relative "env"
 
 module CypressRails
-  class Config < Struct.new(:dir, :port, :base_path, :transactional_server, :cypress_cli_opts, keyword_init: true)
+  class Config < Struct.new(:dir, :host, :port, :base_path, :transactional_server, :cypress_cli_opts, keyword_init: true)
     def initialize(
       dir: Env.fetch("CYPRESS_RAILS_DIR", default: Dir.pwd),
+      host: Env.fetch("CYPRESS_RAILS_HOST"),
       port: Env.fetch("CYPRESS_RAILS_PORT"),
       base_path: Env.fetch("CYPRESS_RAILS_BASE_PATH", default: "/"),
       transactional_server: Env.fetch("CYPRESS_RAILS_TRANSACTIONAL_SERVER", type: :boolean, default: true),
@@ -18,6 +19,7 @@ module CypressRails
         cypress-rails configuration:
         ============================
          CYPRESS_RAILS_DIR.....................#{dir.inspect}
+         CYPRESS_RAILS_HOST....................#{host.inspect}
          CYPRESS_RAILS_PORT....................#{port.inspect}
          CYPRESS_RAILS_BASE_PATH...............#{base_path.inspect}
          CYPRESS_RAILS_TRANSACTIONAL_SERVER....#{transactional_server.inspect}

--- a/lib/cypress-rails/launches_cypress.rb
+++ b/lib/cypress-rails/launches_cypress.rb
@@ -20,6 +20,7 @@ module CypressRails
         @manages_transactions.begin_transaction
       end
       server = @starts_rails_server.call(
+        host: config.host,
         port: config.port,
         transactional_server: config.transactional_server
       )
@@ -27,12 +28,16 @@ module CypressRails
 
       set_exit_hooks!(config)
 
-      command = <<~EXEC
-        CYPRESS_BASE_URL="http://#{server.host}:#{server.port}#{config.base_path}" "#{bin}" #{command} --project "#{config.dir}" #{config.cypress_cli_opts}
-      EXEC
+      if command.nil?
+        sleep
+      else
+        command = <<~EXEC
+          CYPRESS_BASE_URL="http://#{server.host}:#{server.port}#{config.base_path}" "#{bin}" #{command} --project "#{config.dir}" #{config.cypress_cli_opts}
+        EXEC
 
-      puts "\nLaunching Cypress…\n$ #{command}\n"
-      system command
+        puts "\nLaunching Cypress…\n$ #{command}\n"
+        system command
+      end
     end
 
     private

--- a/lib/cypress-rails/starts_rails_server.rb
+++ b/lib/cypress-rails/starts_rails_server.rb
@@ -3,10 +3,11 @@ require_relative "server"
 
 module CypressRails
   class StartsRailsServer
-    def call(port:, transactional_server:)
+    def call(port:, transactional_server:, host: nil)
       configure_rails_to_run_our_state_reset_on_every_request!(transactional_server)
       app = create_rack_app
-      Server.new(app, port: port).tap do |server|
+      optional_args = { host: host }.compact
+      Server.new(app, port: port, **optional_args).tap do |server|
         server.boot
       end
     end


### PR DESCRIPTION
My specific usecase: we run our app inside a docker container. However, I'm setting up Cypress *outside* the container. I've created a custom rake task like this:

```ruby
namespace :cypress do
  desc "Launch the app in a test environment suitable for Cypress"
  task open_server: :environment do
    config = CypressRails::Config.new
    config.host = '0.0.0.0'
    config.port = 3000
    CypressRails::LaunchesCypress.new.call(nil, config)
  end
end
```

The command is `nil`. This way, cypress-rails doesn't attempt to launch Cypress inside the container. The server can be launched independently of Cypress. It is also necessary for the server to bind to `0.0.0.0`. Otherwise, the server doesn't respond to requests through the docker proxy.