### PR TITLE
cypress:init compatibility with Ruby 2.4

### DIFF
--- a/lib/cypress-rails/config.rb
+++ b/lib/cypress-rails/config.rb
@@ -1,7 +1,9 @@
 require_relative "env"
 
 module CypressRails
-  class Config < Struct.new(:dir, :host, :port, :base_path, :transactional_server, :cypress_cli_opts, keyword_init: true)
+  class Config
+    attr_accessor :dir, :host, :port, :base_path, :transactional_server, :cypress_cli_opts
+
     def initialize(
       dir: Env.fetch("CYPRESS_RAILS_DIR", default: Dir.pwd),
       host: Env.fetch("CYPRESS_RAILS_HOST", default: "127.0.0.1"),
@@ -10,7 +12,12 @@ module CypressRails
       transactional_server: Env.fetch("CYPRESS_RAILS_TRANSACTIONAL_SERVER", type: :boolean, default: true),
       cypress_cli_opts: Env.fetch("CYPRESS_RAILS_CYPRESS_OPTS", default: "")
     )
-      super
+      @dir = dir
+      @host = host
+      @port = port
+      @base_path = base_path
+      @transactional_server = transactional_server
+      @cypress_cli_opts = cypress_cli_opts
     end
 
     def to_s


### PR DESCRIPTION
Resolves this error on Ruby 2.4:

![image](https://user-images.githubusercontent.com/2137944/95265110-26d87000-07f6-11eb-98ed-3e51c5fba688.png)


Struct keyword init seems to be a Ruby 2.5 feature: https://blog.bigbinary.com/2018/01/16/ruby-2-5-allows-creating-structs-with-keyword-arguments.html