### PR TITLE
chore: address a missing constant and autoloading issue

### DIFF
--- a/example/an_app/app/models/application_record.rb
+++ b/example/an_app/app/models/application_record.rb
@@ -1,3 +1,4 @@
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
+  connects_to database: { writing: :primary, reading: :primary_replica }
 end

--- a/example/an_app/config/database.yml
+++ b/example/an_app/config/database.yml
@@ -9,17 +9,38 @@ default: &default
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   timeout: 5000
 
-development:
+development_common: &development_common
   <<: *default
   database: db/development.sqlite3
+
+development:
+  primary:
+    <<: *development_common
+  primary:
+    <<: *development_common
+    replica: true
+
+test_common: &test_common
+  <<: *default
+  database: db/test.sqlite3
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
-  <<: *default
-  database: db/test.sqlite3
+  primary:
+    <<: *test_common
+  primary_replica:
+    <<: *test_common
+    replica: true
 
-production:
+production_common: &production_common
   <<: *default
   database: db/production.sqlite3
+
+production:
+  primary:
+    <<: *production_common
+  primary_replica:
+    <<: *production_common
+    replica: true

--- a/lib/cypress-rails/manages_transactions.rb
+++ b/lib/cypress-rails/manages_transactions.rb
@@ -16,6 +16,8 @@ module CypressRails
       # When connections are established in the future, begin a transaction too
       @connection_subscriber = ActiveSupport::Notifications.subscribe("!connection.active_record") { |_, _, _, _, payload|
         if payload.key?(:spec_name) && (spec_name = payload[:spec_name])
+          setup_shared_connection_pool
+
           begin
             connection = ActiveRecord::Base.connection_handler.retrieve_connection(spec_name)
           rescue ActiveRecord::ConnectionNotEstablished

--- a/lib/cypress-rails/manages_transactions.rb
+++ b/lib/cypress-rails/manages_transactions.rb
@@ -16,11 +16,9 @@ module CypressRails
       # When connections are established in the future, begin a transaction too
       @connection_subscriber = ActiveSupport::Notifications.subscribe("!connection.active_record") { |_, _, _, _, payload|
         if payload.key?(:spec_name) && (spec_name = payload[:spec_name])
-          setup_shared_connection_pool
-
           begin
             connection = ActiveRecord::Base.connection_handler.retrieve_connection(spec_name)
-          rescue ConnectionNotEstablished
+          rescue ActiveRecord::ConnectionNotEstablished
             connection = nil
           end
 


### PR DESCRIPTION
# Motivation
I just recently started playing around with `cypress-rails`, and everything seemed to work pretty well until I changed some code and re-ran the tests. In the Cypress runner, I would receive a `An unhandled lowlevel error occurred. The application logs may have details.` message. In my app logs, I'd see that the `ConnectionNotEstablished` constant was not defined. After fixing the constant issue, I continued to get a constant issue, and the only resolution was to remove the `setup_shared_connection_pool` call in the `ActiveSupport::Notifications.subscribe` callback. I don't know why this fixed the issue for me, and I can't speak to the side effects this may cause, but I wanted to propose this change to at least start a conversation about it. Thanks for reviewing!

# Reproducing the issue (from the example app folder)
1. Run `bin/rails cypress:open`
2. Run the `compliments.js` test
3. Observe that it passes
4. Make a change in `example/an_app/app/models/compliment.rb` (or any autoloaded file)
5. Run the tests again
6. Observe that the tests fail and an `ActiveRecord::ConnectionNotEstablished` error is logged
