### PR TITLE
feat: add after_server_boot hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,11 @@ will execute before the server or any transaction has been started. If you use
 Rails fixtures, it may make sense to load them here, so they don't need to be
 re-inserted for each request
 
+### after_server_start
+
+Pass a block to `CypressRails.hooks.after_server_start` to register a hook that
+will execute after the server has booted.
+
 ### after_transaction_start
 
 If there's any custom behavior or state management you want to do inside the

--- a/example/an_app/app/controllers/static_pages_controller.rb
+++ b/example/an_app/app/controllers/static_pages_controller.rb
@@ -1,0 +1,4 @@
+class StaticPagesController < ApplicationController
+  def external
+  end
+end

--- a/example/an_app/app/views/static_pages/external.html.erb
+++ b/example/an_app/app/views/static_pages/external.html.erb
@@ -1,0 +1,21 @@
+<h1>Getting external compliments!</h1>
+
+<script type="text/javascript">
+  fetch('http://127.0.0.1:8080/compliment.json')
+  .then(response => response.json())
+  .then(data => {
+    // create a new div element
+    const newDiv = document.createElement("div");
+
+    // and give it some content
+    const newContent = document.createTextNode(data.complimentText);
+
+    // add the text node to the newly created div
+    newDiv.appendChild(newContent);
+    newDiv.id = 'external_compliment';
+
+    // add the newly created element and its content into the DOM
+    document.body.append(newDiv);
+  })
+  .catch((e) => { console.log(e) })
+</script>

--- a/example/an_app/config/initializers/cypress_rails_initializer.rb
+++ b/example/an_app/config/initializers/cypress_rails_initializer.rb
@@ -1,4 +1,5 @@
 return unless Rails.env.test?
+require './lib/external_service'
 
 Rails.application.load_tasks unless defined?(Rake::Task)
 
@@ -13,6 +14,9 @@ CypressRails.hooks.after_server_start do
   if Compliment.count == 4
     raise "I cannot run tests without compliments!"
   end
+
+  # Start up external service
+  ExternalService.start_service
 end
 
 CypressRails.hooks.after_transaction_start do
@@ -29,4 +33,7 @@ end
 CypressRails.hooks.before_server_stop do
   # Purge and reload the test database so we don't leave our fixtures in there
   Rake::Task["db:test:prepare"].invoke
+
+  # Stops the external service
+  ExternalService.stop_service
 end

--- a/example/an_app/config/initializers/cypress_rails_initializer.rb
+++ b/example/an_app/config/initializers/cypress_rails_initializer.rb
@@ -7,6 +7,11 @@ CypressRails.hooks.before_server_start do
   Rake::Task["db:fixtures:load"].invoke
 end
 
+CypressRails.hooks.after_server_start do
+  # After the server has  booted we add the compliment!
+  puts "Congrats the server has started!"
+end
+
 CypressRails.hooks.after_transaction_start do
   # After each transaction, add this compliment (will be rolled back on reset)
   Compliment.create(text: "You are courageous")

--- a/example/an_app/config/initializers/cypress_rails_initializer.rb
+++ b/example/an_app/config/initializers/cypress_rails_initializer.rb
@@ -8,8 +8,11 @@ CypressRails.hooks.before_server_start do
 end
 
 CypressRails.hooks.after_server_start do
-  # After the server has  booted we add the compliment!
-  puts "Congrats the server has started!"
+  # After the server has  booted we add the compliment to the existing fixture list!
+  Compliment.create(text: "This shall be the first.")
+  if Compliment.count == 4
+    raise "I cannot run tests without compliments!"
+  end
 end
 
 CypressRails.hooks.after_transaction_start do

--- a/example/an_app/config/routes.rb
+++ b/example/an_app/config/routes.rb
@@ -1,5 +1,6 @@
 Rails.application.routes.draw do
   get "/an_static_form", to: "forms#static"
+  get "/external_request", to: "static_pages#external"
 
   resources :compliments
 

--- a/example/an_app/cypress/integration/external-service.js
+++ b/example/an_app/cypress/integration/external-service.js
@@ -1,0 +1,9 @@
+describe('External Service', () => {
+  it('Fetches data from an external, running server', () => {
+    cy.visit('/external_request');
+    cy.get('#external_compliment').should(
+      'have.text',
+      'Wow, look at you fetch data!'
+    );
+  });
+});

--- a/example/an_app/external_service/compliment.json
+++ b/example/an_app/external_service/compliment.json
@@ -1,0 +1,3 @@
+{
+  "complimentText": "Wow, look at you fetch data!"
+}

--- a/example/an_app/lib/external_service.rb
+++ b/example/an_app/lib/external_service.rb
@@ -1,0 +1,33 @@
+class ExternalService
+  class << self
+    def start_service
+      @job_pid = fork do
+        exec "yarn start"
+      end
+      Process.detach(@job_pid)
+    end
+
+    def stop_service
+      all_processes.each do |pid|
+        Process.kill('SIGINT', pid.to_i)
+      end
+    end
+
+    def all_processes
+      get_child_processes << @job_pid
+    end
+
+    def get_child_processes
+      pipe = IO.popen("ps -ef | grep #{@job_pid}")
+
+      child_pids = pipe.readlines.map do |line|
+        parts = line.split(/\s+/)
+        parts[1] if parts[2] == @job_pid.to_s && parts[1] != pipe.pid.to_s
+      end.compact
+
+      pipe.close
+      # Reverse the child processes to keep the correct tree spawn structure
+      child_pids.reverse
+    end
+  end
+end

--- a/example/an_app/package.json
+++ b/example/an_app/package.json
@@ -1,9 +1,13 @@
 {
   "name": "an_app",
   "private": true,
+  "scripts": {
+    "start": "http-server external_service --cors"
+  },
   "dependencies": {
     "@rails/ujs": "^6.0.0-alpha",
-    "@rails/webpacker": "5.2.1"
+    "@rails/webpacker": "5.2.1",
+    "http-server": "^0.12.3"
   },
   "version": "0.1.0",
   "devDependencies": {

--- a/example/an_app/yarn.lock
+++ b/example/an_app/yarn.lock
@@ -1485,6 +1485,11 @@ base@^0.11.1:
     mixin-deep "^1.2.0"
     pascalcase "^0.1.1"
 
+basic-auth@^1.0.3:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/basic-auth/-/basic-auth-1.1.0.tgz#45221ee429f7ee1e5035be3f51533f1cdfd29884"
+  integrity sha1-RSIe5Cn37h5QNb4/UVM/HN/SmIQ=
+
 batch@0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/batch/-/batch-0.6.1.tgz#dc34314f4e679318093fc760272525f94bf25c16"
@@ -2099,7 +2104,7 @@ colorette@^1.2.1:
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-1.2.1.tgz#4d0b921325c14faf92633086a536db6e89564b1b"
   integrity sha512-puCDz0CzydiSYOrnXpz/PKd69zRrribezjtE9yd4zvytoRc8+RY/KJPvtPFKZS3E3wP6neGyMe0vOTlHO5L3Pw==
 
-colors@^1.1.2:
+colors@^1.1.2, colors@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
   integrity sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==
@@ -2265,6 +2270,11 @@ core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
   integrity sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
+
+corser@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/corser/-/corser-2.0.1.tgz#8eda252ecaab5840dcd975ceb90d9370c819ff87"
+  integrity sha1-jtolLsqrWEDc2XXOuQ2TcMgZ/4c=
 
 cosmiconfig@^5.0.0:
   version "5.2.1"
@@ -2826,6 +2836,16 @@ ecc-jsbn@~0.1.1:
   dependencies:
     jsbn "~0.1.0"
     safer-buffer "^2.1.0"
+
+ecstatic@^3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/ecstatic/-/ecstatic-3.3.2.tgz#6d1dd49814d00594682c652adb66076a69d46c48"
+  integrity sha512-fLf9l1hnwrHI2xn9mEDT7KIi22UDqA2jaCwyCbSUJh9a1V+LEUSL/JO/6TIz/QyuBURWUHrFL5Kg2TtO1bkkog==
+  dependencies:
+    he "^1.1.1"
+    mime "^1.6.0"
+    minimist "^1.1.0"
+    url-join "^2.0.5"
 
 ee-first@1.1.1:
   version "1.1.1"
@@ -3501,6 +3521,15 @@ get-intrinsic@^1.0.0:
     has "^1.0.3"
     has-symbols "^1.0.1"
 
+get-intrinsic@^1.0.2:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.1.1.tgz#15f59f376f855c446963948f0d24cd3637b4abc6"
+  integrity sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==
+  dependencies:
+    function-bind "^1.1.1"
+    has "^1.0.3"
+    has-symbols "^1.0.1"
+
 get-stdin@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-4.0.1.tgz#b968c6b0a04384324902e8bf1a5df32579a450fe"
@@ -3739,6 +3768,11 @@ hash.js@^1.0.0, hash.js@^1.0.3:
     inherits "^2.0.3"
     minimalistic-assert "^1.0.1"
 
+he@^1.1.1:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
+  integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
+
 hex-color-regex@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/hex-color-regex/-/hex-color-regex-1.1.0.tgz#4c06fccb4602fe2602b3c93df82d7e7dbf1a8a8e"
@@ -3847,7 +3881,7 @@ http-proxy-middleware@0.19.1:
     lodash "^4.17.11"
     micromatch "^3.1.10"
 
-http-proxy@^1.17.0:
+http-proxy@^1.17.0, http-proxy@^1.18.0:
   version "1.18.1"
   resolved "https://registry.yarnpkg.com/http-proxy/-/http-proxy-1.18.1.tgz#401541f0534884bbf95260334e72f88ee3976549"
   integrity sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==
@@ -3855,6 +3889,22 @@ http-proxy@^1.17.0:
     eventemitter3 "^4.0.0"
     follow-redirects "^1.0.0"
     requires-port "^1.0.0"
+
+http-server@^0.12.3:
+  version "0.12.3"
+  resolved "https://registry.yarnpkg.com/http-server/-/http-server-0.12.3.tgz#ba0471d0ecc425886616cb35c4faf279140a0d37"
+  integrity sha512-be0dKG6pni92bRjq0kvExtj/NrrAd28/8fCXkaI/4piTwQMSDSLMhWyW0NI1V+DBI3aa1HMlQu46/HjVLfmugA==
+  dependencies:
+    basic-auth "^1.0.3"
+    colors "^1.4.0"
+    corser "^2.0.1"
+    ecstatic "^3.3.2"
+    http-proxy "^1.18.0"
+    minimist "^1.2.5"
+    opener "^1.5.1"
+    portfinder "^1.0.25"
+    secure-compare "3.0.1"
+    union "~0.5.0"
 
 http-signature@~1.2.0:
   version "1.2.0"
@@ -4882,7 +4932,7 @@ mime-types@^2.1.12, mime-types@~2.1.17, mime-types@~2.1.19, mime-types@~2.1.24:
   dependencies:
     mime-db "1.44.0"
 
-mime@1.6.0:
+mime@1.6.0, mime@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
   integrity sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==
@@ -4929,7 +4979,7 @@ minimatch@^3.0.4, minimatch@~3.0.2:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.5:
+minimist@^1.1.0, minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
@@ -5282,7 +5332,7 @@ object-copy@^0.1.0:
     define-property "^0.2.5"
     kind-of "^3.0.3"
 
-object-inspect@^1.8.0:
+object-inspect@^1.8.0, object-inspect@^1.9.0:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.9.0.tgz#c90521d74e1127b67266ded3394ad6116986533a"
   integrity sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw==
@@ -5385,6 +5435,11 @@ onetime@^5.1.0:
   integrity sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==
   dependencies:
     mimic-fn "^2.1.0"
+
+opener@^1.5.1:
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/opener/-/opener-1.5.2.tgz#5d37e1f35077b9dcac4301372271afdeb2a13598"
+  integrity sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==
 
 opn@^5.5.0:
   version "5.5.0"
@@ -5710,7 +5765,7 @@ pnp-webpack-plugin@^1.6.4:
   dependencies:
     ts-pnp "^1.1.6"
 
-portfinder@^1.0.26:
+portfinder@^1.0.25, portfinder@^1.0.26:
   version "1.0.28"
   resolved "https://registry.yarnpkg.com/portfinder/-/portfinder-1.0.28.tgz#67c4622852bd5374dd1dd900f779f53462fac778"
   integrity sha512-Se+2isanIcEqf2XMHjyUKskczxbPH7dQnlMjXX6+dybayyHvAf/TCgyMRlzf/B6QDhAEFOGes0pzRo3by4AbMA==
@@ -6479,6 +6534,13 @@ qs@6.7.0:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.7.0.tgz#41dc1a015e3d581f1621776be31afb2876a9b1bc"
   integrity sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==
 
+qs@^6.4.0:
+  version "6.10.1"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.10.1.tgz#4931482fa8d647a5aab799c5271d2133b981fb6a"
+  integrity sha512-M528Hph6wsSVOBiYUnGf+K/7w0hNshs/duGsNXPUCLH5XAqjEtiPGwNONLV0tBH8NoGb0mvD5JubnUTrujKDTg==
+  dependencies:
+    side-channel "^1.0.4"
+
 qs@~6.5.2:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
@@ -6939,6 +7001,11 @@ scss-tokenizer@^0.2.3:
     js-base64 "^2.1.8"
     source-map "^0.4.2"
 
+secure-compare@3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/secure-compare/-/secure-compare-3.0.1.tgz#f1a0329b308b221fae37b9974f3d578d0ca999e3"
+  integrity sha1-8aAymzCLIh+uN7mXTz1XjQypmeM=
+
 select-hose@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/select-hose/-/select-hose-2.0.0.tgz#625d8658f865af43ec962bfc376a37359a4994ca"
@@ -7095,6 +7162,15 @@ shebang-regex@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
+
+side-channel@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/side-channel/-/side-channel-1.0.4.tgz#efce5c8fdc104ee751b25c58d4290011fa5ea2cf"
+  integrity sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==
+  dependencies:
+    call-bind "^1.0.0"
+    get-intrinsic "^1.0.2"
+    object-inspect "^1.9.0"
 
 signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.3"
@@ -7809,6 +7885,13 @@ union-value@^1.0.0:
     is-extendable "^0.1.1"
     set-value "^2.0.1"
 
+union@~0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/union/-/union-0.5.0.tgz#b2c11be84f60538537b846edb9ba266ba0090075"
+  integrity sha512-N6uOhuW6zO95P3Mel2I2zMsbsanvvtgn6jVqJv4vbVcz/JN0OkL9suomjQGmWtxJQXOCqUJvquc1sMeNz/IwlA==
+  dependencies:
+    qs "^6.4.0"
+
 uniq@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/uniq/-/uniq-1.0.1.tgz#b31c5ae8254844a3a8281541ce2b04b865a734ff"
@@ -7882,6 +7965,11 @@ urix@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
   integrity sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=
+
+url-join@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/url-join/-/url-join-2.0.5.tgz#5af22f18c052a000a48d7b82c5e9c2e2feeda728"
+  integrity sha1-WvIvGMBSoACkjXuCxenC4v7tpyg=
 
 url-parse@^1.4.3:
   version "1.4.7"

--- a/lib/cypress-rails/initializer_hooks.rb
+++ b/lib/cypress-rails/initializer_hooks.rb
@@ -13,7 +13,7 @@ module CypressRails
     end
 
     def after_server_start(&blk)
-      register(:before_server_start, blk)
+      register(:after_server_start, blk)
     end
 
     def after_transaction_start(&blk)

--- a/lib/cypress-rails/initializer_hooks.rb
+++ b/lib/cypress-rails/initializer_hooks.rb
@@ -12,6 +12,10 @@ module CypressRails
       register(:before_server_start, blk)
     end
 
+    def after_server_start(&blk)
+      register(:before_server_start, blk)
+    end
+
     def after_transaction_start(&blk)
       register(:after_transaction_start, blk)
     end

--- a/lib/cypress-rails/server.rb
+++ b/lib/cypress-rails/server.rb
@@ -3,6 +3,7 @@
 require "uri"
 require "net/http"
 require "rack"
+require_relative "initializer_hooks"
 require_relative "server/middleware"
 require_relative "server/checker"
 require_relative "server/timer"
@@ -32,6 +33,7 @@ module CypressRails
       @port ||= Server.ports[port_key]
       @port ||= find_available_port(host)
       @checker = Checker.new(@host, @port)
+      @initializer_hooks = InitializerHooks.instance
     end
 
     def reset_error!
@@ -78,6 +80,7 @@ module CypressRails
           raise "Rack application timed out during boot" if timer.expired?
 
           @server_thread.join(0.1)
+          @initializer_hooks.run(:after_server_start)
         end
       end
 


### PR DESCRIPTION
# Why?

For a project I'm on, there is a requirement for our GraphQL gateway to be setup _after_ our Rails server is booted. This constraint is due to the gateway setup, but the hook may help with other services or configuration that needs to be stood up alongside the Rails server in test.