### PR TITLE
fix: ConnectionNotEstablished namespacing

### DIFF
--- a/lib/cypress-rails/manages_transactions.rb
+++ b/lib/cypress-rails/manages_transactions.rb
@@ -20,7 +20,7 @@ module CypressRails
 
           begin
             connection = ActiveRecord::Base.connection_handler.retrieve_connection(spec_name)
-          rescue ConnectionNotEstablished
+          rescue ActiveRecord::ConnectionNotEstablished
             connection = nil
           end
 


### PR DESCRIPTION
Fixes a bug where `ConnectionNotEstablished` is an undefined constant. The reference in Rails ([here](https://github.com/rails/rails/blob/291a3d2ef29a3842d1156ada7526f4ee60dd2b59/activerecord/lib/active_record/test_fixtures.rb#L140)) is already namespaced with the module definition, but in our case, we need to namespace it to ensure we are rescuing specifically from `ActiveRecord` and not another constant.