### PR TITLE
cleanup: remove custom process removal

### DIFF
--- a/example/an_app/config/initializers/cypress_rails_initializer.rb
+++ b/example/an_app/config/initializers/cypress_rails_initializer.rb
@@ -33,7 +33,4 @@ end
 CypressRails.hooks.before_server_stop do
   # Purge and reload the test database so we don't leave our fixtures in there
   Rake::Task["db:test:prepare"].invoke
-
-  # Stops the external service
-  ExternalService.stop_service
 end

--- a/example/an_app/lib/external_service.rb
+++ b/example/an_app/lib/external_service.rb
@@ -6,28 +6,5 @@ class ExternalService
       }
       Process.detach(@job_pid)
     end
-
-    def stop_service
-      all_processes.each do |pid|
-        Process.kill("SIGINT", pid.to_i)
-      end
-    end
-
-    def all_processes
-      get_child_processes << @job_pid
-    end
-
-    def get_child_processes
-      pipe = IO.popen("ps -ef | grep #{@job_pid}")
-
-      child_pids = pipe.readlines.map { |line|
-        parts = line.split(/\s+/)
-        parts[1] if parts[2] == @job_pid.to_s && parts[1] != pipe.pid.to_s
-      }.compact
-
-      pipe.close
-      # Reverse the child processes to keep the correct tree spawn structure
-      child_pids.reverse
-    end
   end
 end


### PR DESCRIPTION
Ensuring the grandchild process of `http-party` closes after run is functionality that doesn't need to exist in this demo application. Keeping the initializer example clean and without managing processes for all OS are caught and ended do not need to be in this gem.

Closes #70