### PR TITLE
Change startup script to require a string

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,14 @@ preferred environment variables project-wide using a tool like
   be rolled back on exit (similar to running a Rails System test)
 * **CYPRESS_RAILS_CYPRESS_OPTS** (default: _none_) any options you want to
   forward to the Cypress CLI when running its `open` or `run` commands.
+* **CYPRESS_BASE_URL** (default: _none_) the url where to find your frontend application
+  if you run it seperately from your Rails application
+* **CYPRESS_DIR** (default: _none_) the path to your Cypress test files if you keep them 
+  outside of the Rails application
+* **CYPRESS_RAILS_CYPRESS_PATH** (default: `"node_modules/.bin/cypress"`) The path to your
+  Cypress executable. You need to modify this if you have Cypress installed in a different
+  directory than your Rails application
+
 
 #### Example: Running a single spec from the command line
 

--- a/exe/cypress-rails
+++ b/exe/cypress-rails
@@ -3,7 +3,7 @@
 ENV["RAILS_ENV"] ||= "test"
 require "pathname"
 require "cypress-rails"
-require Pathname.new(CypressRails::Config.new.dir).join("config/environment")
+require Pathname.new(CypressRails::Config.new.dir).join("config/environment").to_s
 
 command = ARGV[0]
 case command

--- a/lib/cypress-rails/config.rb
+++ b/lib/cypress-rails/config.rb
@@ -2,7 +2,15 @@ require_relative "env"
 
 module CypressRails
   class Config
-    attr_accessor :dir, :host, :port, :base_path, :transactional_server, :cypress_cli_opts
+    attr_accessor :dir,
+                  :host,
+                  :port,
+                  :base_path,
+                  :transactional_server,
+                  :cypress_cli_opts,
+                  :cypress_path,
+                  :cypress_base_url,
+                  :cypress_dir
 
     def initialize(
       dir: Env.fetch("CYPRESS_RAILS_DIR", default: Dir.pwd),
@@ -10,7 +18,10 @@ module CypressRails
       port: Env.fetch("CYPRESS_RAILS_PORT"),
       base_path: Env.fetch("CYPRESS_RAILS_BASE_PATH", default: "/"),
       transactional_server: Env.fetch("CYPRESS_RAILS_TRANSACTIONAL_SERVER", type: :boolean, default: true),
-      cypress_cli_opts: Env.fetch("CYPRESS_RAILS_CYPRESS_OPTS", default: "")
+      cypress_cli_opts: Env.fetch("CYPRESS_RAILS_CYPRESS_OPTS", default: ""),
+      cypress_path: Env.fetch("CYPRESS_RAILS_CYPRESS_PATH", default: "node_modules/.bin/cypress"),
+      cypress_base_url: Env.fetch("CYPRESS_BASE_URL", default: nil),
+      cypress_dir: Env.fetch("CYPRESS_DIR", default: nil)
     )
       @dir = dir
       @host = host
@@ -18,6 +29,9 @@ module CypressRails
       @base_path = base_path
       @transactional_server = transactional_server
       @cypress_cli_opts = cypress_cli_opts
+      @cypress_path = cypress_path
+      @cypress_base_url = cypress_base_url
+      @cypress_dir = cypress_dir
     end
 
     def to_s
@@ -31,6 +45,9 @@ module CypressRails
          CYPRESS_RAILS_BASE_PATH...............#{base_path.inspect}
          CYPRESS_RAILS_TRANSACTIONAL_SERVER....#{transactional_server.inspect}
          CYPRESS_RAILS_CYPRESS_OPTS............#{cypress_cli_opts.inspect}
+         CYPRESS_RAILS_CYPRESS_PATH............#{cypress_path.inspect}
+         CYPRESS_BASE_URL......................#{cypress_base_url.inspect}
+         CYPRESS_DIR...........................#{cypress_dir.inspect}
 
       DESC
     end

--- a/lib/cypress-rails/finds_bin.rb
+++ b/lib/cypress-rails/finds_bin.rb
@@ -1,12 +1,12 @@
 require "pathname"
+require_relative "config"
 
 module CypressRails
   class FindsBin
-    LOCAL_PATH = "node_modules/.bin/cypress"
-
-    def call(dir = Dir.pwd)
-      local_path = Pathname.new(dir).join(LOCAL_PATH)
+    def call(dir = Dir.pwd, config = Config.new)
+      local_path = config.cypress_path
       if File.exist?(local_path)
+        # local_path = Pathname.new(dir).join(LOCAL_PATH)
         local_path
       else
         "cypress"

--- a/lib/cypress-rails/launches_cypress.rb
+++ b/lib/cypress-rails/launches_cypress.rb
@@ -28,8 +28,11 @@ module CypressRails
 
       set_exit_hooks!(config)
 
+      cypress_base_url = config.cypress_base_url || "http://#{server.host}:#{server.port}#{config.base_path}"
+      cypress_dir = config.cypress_dir || config.dir
+
       command = <<~EXEC
-        CYPRESS_BASE_URL="http://#{server.host}:#{server.port}#{config.base_path}" "#{bin}" #{command} --project "#{config.dir}" #{config.cypress_cli_opts}
+        CYPRESS_BASE_URL=#{cypress_base_url.to_s} "#{bin}" #{command} --project "#{cypress_dir}" #{config.cypress_cli_opts}
       EXEC
 
       puts "\nLaunching Cypress…\n$ #{command}\n"


### PR DESCRIPTION
If you configured the `CYPRESS_RAILS_DIR` environment variable through the command-line like this `CYPRESS_RAILS_DIR="/foo/bar/project" bin/rake cypress:run` then you got a `TypeError` like this: `no implicit conversion of Pathname into String (TypeError)`.

The `Pathname` object needs to be converted into a `String` before requiring it.