### PR TITLE
support Rails 6.1.4 by making shared_connection_pool optional

### DIFF
--- a/lib/cypress-rails/config.rb
+++ b/lib/cypress-rails/config.rb
@@ -2,7 +2,7 @@ require_relative "env"
 
 module CypressRails
   class Config
-    attr_accessor :dir, :host, :port, :base_path, :transactional_server, :cypress_cli_opts
+    attr_accessor :dir, :host, :port, :base_path, :transactional_server, :shared_connection_pool, :cypress_cli_opts
 
     def initialize(
       dir: Env.fetch("CYPRESS_RAILS_DIR", default: Dir.pwd),
@@ -10,6 +10,7 @@ module CypressRails
       port: Env.fetch("CYPRESS_RAILS_PORT"),
       base_path: Env.fetch("CYPRESS_RAILS_BASE_PATH", default: "/"),
       transactional_server: Env.fetch("CYPRESS_RAILS_TRANSACTIONAL_SERVER", type: :boolean, default: true),
+      shared_connection_pool: Env.fetch("CYPRESS_RAILS_SHARED_CONNECTION_POOL", type: :boolean, default: true),
       cypress_cli_opts: Env.fetch("CYPRESS_RAILS_CYPRESS_OPTS", default: "")
     )
       @dir = dir
@@ -17,6 +18,7 @@ module CypressRails
       @port = port
       @base_path = base_path
       @transactional_server = transactional_server
+      @shared_connection_pool = shared_connection_pool
       @cypress_cli_opts = cypress_cli_opts
     end
 
@@ -30,6 +32,7 @@ module CypressRails
          CYPRESS_RAILS_PORT....................#{port.inspect}
          CYPRESS_RAILS_BASE_PATH...............#{base_path.inspect}
          CYPRESS_RAILS_TRANSACTIONAL_SERVER....#{transactional_server.inspect}
+         CYPRESS_RAILS_SHARED_CONNECTION_POOL..#{shared_connection_pool.inspect}
          CYPRESS_RAILS_CYPRESS_OPTS............#{cypress_cli_opts.inspect}
 
       DESC

--- a/lib/cypress-rails/launches_cypress.rb
+++ b/lib/cypress-rails/launches_cypress.rb
@@ -15,6 +15,7 @@ module CypressRails
 
     def call(command, config)
       puts config.to_s
+      @manages_transactions.config = config
       @initializer_hooks.run(:before_server_start)
       if config.transactional_server
         @manages_transactions.begin_transaction

--- a/lib/cypress-rails/manages_transactions.rb
+++ b/lib/cypress-rails/manages_transactions.rb
@@ -2,6 +2,8 @@ require_relative "initializer_hooks"
 
 module CypressRails
   class ManagesTransactions
+    attr_writer :config
+
     def self.instance
       @instance ||= new
     end
@@ -56,7 +58,7 @@ module CypressRails
     end
 
     def gather_connections
-      setup_shared_connection_pool
+      setup_shared_connection_pool if @config.shared_connection_pool
 
       ActiveRecord::Base.connection_handler.connection_pool_list.map(&:connection)
     end


### PR DESCRIPTION
this commit adds a `CYPRESS_RAILS_SHARED_CONNECTION_POOL` env var which defaults to `true`. if you set it to `false`, you can run cypress-rails with Rails 6.1.4 and no shared connection pool.

caveats:
* https://github.com/testdouble/cypress-rails/pull/89 seems to run fine without this step; I couldn't tell you why.
* I don't have an app handy which uses a shared connection pool to test this PR on.

this is obviously not a perfect solution. my client's app doesn't use a shared connection pool, so it solves the problem for my limited use case, but it may only be useful for this project as a starting point, or as a stopgap, for other users who don't have shared connection pools to consider either.

more discussion of the issue in #88.