### PR TITLE
fix: clamp puma config to avoid deprecation warning

### DIFF
--- a/lib/cypress-rails/server/puma.rb
+++ b/lib/cypress-rails/server/puma.rb
@@ -11,6 +11,7 @@ module CypressRails
         options = default_options # .merge(options)
 
         conf = Rack::Handler::Puma.config(app, options)
+        conf.clamp
         events = ::Puma::Events.stdio
 
         puma_ver = Gem::Version.new(::Puma::Const::PUMA_VERSION)


### PR DESCRIPTION
# Changes

Calls clamp on the puma config to avoid an issue where the environment value has not been finalized from a proc to a string, leading to a deprecation warning.

- [Issue from Puma repo](https://github.com/puma/puma/issues/2455)
- [Similar fix in Capybara](https://github.com/teamcapybara/capybara/pull/2413)
