### PR TITLE
Fix deprecation warning for clear_active_connections! call

### DIFF
--- a/lib/cypress-rails/manages_transactions.rb
+++ b/lib/cypress-rails/manages_transactions.rb
@@ -46,7 +46,7 @@ module CypressRails
       end
       @connections.clear
 
-      ActiveRecord::Base.clear_active_connections!
+      ActiveRecord::Base.connection_handler.clear_active_connections!
     end
 
     private


### PR DESCRIPTION
This one-liner fixes a Rails deprecation warning that has been popping up in my recent builds:

>```DEPRECATION WARNING: Calling `ActiveRecord::Base.clear_active_connections! is deprecated. Please call the method directly on the connection handler; for example: `ActiveRecord::Base.connection_handler.clear_active_connections!`. (called from rollback_transaction at /path/to/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/cypress-rails-0.6.0/lib/cypress-rails/manages_transactions.rb:49)```

Looks like this deprecation was added to Rails circa September 2022, https://github.com/rails/rails/pull/45924