### PR TITLE
Add configurability for external Cypress project through additional environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ preferred environment variables project-wide using a tool like
 
 
 * **CYPRESS_RAILS_DIR** (default: `Dir.pwd`) the directory of your project
+* **CYPRESS_DIR** (default: `Dir.pwd`) the directory of your Cypress project
 * **CYPRESS_RAILS_HOST** (default: `"127.0.0.1"`) the hostname to bind to
 * **CYPRESS_RAILS_PORT** (default: _a random available port_) the port to run
   the Rails test server on

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ preferred environment variables project-wide using a tool like
 
 
 * **CYPRESS_RAILS_DIR** (default: `Dir.pwd`) the directory of your Rails project
-* **CYPRESS_DIR** (default: `Dir.pwd`) the directory of your Cypress project
+* **CYPRESS_RAILS_CYPRESS_DIR** (default: _same value as `rails_dir`_) the directory of your Cypress project
 * **CYPRESS_RAILS_HOST** (default: `"127.0.0.1"`) the hostname to bind to
 * **CYPRESS_RAILS_PORT** (default: _a random available port_) the port to run
   the Rails test server on

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ preferred environment variables project-wide using a tool like
 [dotenv](https://github.com/bkeepers/dotenv).
 
 
-* **CYPRESS_RAILS_DIR** (default: `Dir.pwd`) the directory of your project
+* **CYPRESS_RAILS_DIR** (default: `Dir.pwd`) the directory of your Rails project
 * **CYPRESS_DIR** (default: `Dir.pwd`) the directory of your Cypress project
 * **CYPRESS_RAILS_HOST** (default: `"127.0.0.1"`) the hostname to bind to
 * **CYPRESS_RAILS_PORT** (default: _a random available port_) the port to run

--- a/exe/cypress-rails
+++ b/exe/cypress-rails
@@ -3,7 +3,7 @@
 ENV["RAILS_ENV"] ||= "test"
 require "pathname"
 require "cypress-rails"
-require Pathname.new(CypressRails::Config.new.dir).join("config/environment")
+require Pathname.new(CypressRails::Config.new.rails_dir).join("config/environment")
 
 command = ARGV[0]
 case command

--- a/lib/cypress-rails/config.rb
+++ b/lib/cypress-rails/config.rb
@@ -2,10 +2,11 @@ require_relative "env"
 
 module CypressRails
   class Config
-    attr_accessor :dir, :host, :port, :base_path, :transactional_server, :cypress_cli_opts
+    attr_accessor :dir, :cy_dir, :host, :port, :base_path, :transactional_server, :cypress_cli_opts
 
     def initialize(
       dir: Env.fetch("CYPRESS_RAILS_DIR", default: Dir.pwd),
+      cy_dir: Env.fetch("CYPRESS_DIR", default: Dir.pwd),
       host: Env.fetch("CYPRESS_RAILS_HOST", default: "127.0.0.1"),
       port: Env.fetch("CYPRESS_RAILS_PORT"),
       base_path: Env.fetch("CYPRESS_RAILS_BASE_PATH", default: "/"),
@@ -13,6 +14,7 @@ module CypressRails
       cypress_cli_opts: Env.fetch("CYPRESS_RAILS_CYPRESS_OPTS", default: "")
     )
       @dir = dir
+      @cy_dir = cy_dir
       @host = host
       @port = port
       @base_path = base_path

--- a/lib/cypress-rails/config.rb
+++ b/lib/cypress-rails/config.rb
@@ -28,6 +28,7 @@ module CypressRails
         cypress-rails configuration:
         ============================
          CYPRESS_RAILS_DIR.....................#{dir.inspect}
+         CYPRESS_DIR...........................#{cy_dir.inspect}
          CYPRESS_RAILS_HOST....................#{host.inspect}
          CYPRESS_RAILS_PORT....................#{port.inspect}
          CYPRESS_RAILS_BASE_PATH...............#{base_path.inspect}

--- a/lib/cypress-rails/config.rb
+++ b/lib/cypress-rails/config.rb
@@ -2,19 +2,19 @@ require_relative "env"
 
 module CypressRails
   class Config
-    attr_accessor :dir, :cy_dir, :host, :port, :base_path, :transactional_server, :cypress_cli_opts
+    attr_accessor :rails_dir, :cypress_dir, :host, :port, :base_path, :transactional_server, :cypress_cli_opts
 
     def initialize(
-      dir: Env.fetch("CYPRESS_RAILS_DIR", default: Dir.pwd),
-      cy_dir: Env.fetch("CYPRESS_DIR", default: Dir.pwd),
+      rails_dir: Env.fetch("CYPRESS_RAILS_DIR", default: Dir.pwd),
+      cypress_dir: Env.fetch("CYPRESS_DIR", default: Dir.pwd),
       host: Env.fetch("CYPRESS_RAILS_HOST", default: "127.0.0.1"),
       port: Env.fetch("CYPRESS_RAILS_PORT"),
       base_path: Env.fetch("CYPRESS_RAILS_BASE_PATH", default: "/"),
       transactional_server: Env.fetch("CYPRESS_RAILS_TRANSACTIONAL_SERVER", type: :boolean, default: true),
       cypress_cli_opts: Env.fetch("CYPRESS_RAILS_CYPRESS_OPTS", default: "")
     )
-      @dir = dir
-      @cy_dir = cy_dir
+      @rails_dir = rails_dir
+      @cypress_dir = cypress_dir
       @host = host
       @port = port
       @base_path = base_path
@@ -27,8 +27,8 @@ module CypressRails
 
         cypress-rails configuration:
         ============================
-         CYPRESS_RAILS_DIR.....................#{dir.inspect}
-         CYPRESS_DIR...........................#{cy_dir.inspect}
+         CYPRESS_RAILS_DIR.....................#{rails_dir.inspect}
+         CYPRESS_DIR...........................#{cypress_dir.inspect}
          CYPRESS_RAILS_HOST....................#{host.inspect}
          CYPRESS_RAILS_PORT....................#{port.inspect}
          CYPRESS_RAILS_BASE_PATH...............#{base_path.inspect}

--- a/lib/cypress-rails/config.rb
+++ b/lib/cypress-rails/config.rb
@@ -6,7 +6,7 @@ module CypressRails
 
     def initialize(
       rails_dir: Env.fetch("CYPRESS_RAILS_DIR", default: Dir.pwd),
-      cypress_dir: Env.fetch("CYPRESS_DIR", default: Dir.pwd),
+      cypress_dir: Env.fetch("CYPRESS_RAILS_CYPRESS_DIR", default: rails_dir),
       host: Env.fetch("CYPRESS_RAILS_HOST", default: "127.0.0.1"),
       port: Env.fetch("CYPRESS_RAILS_PORT"),
       base_path: Env.fetch("CYPRESS_RAILS_BASE_PATH", default: "/"),
@@ -28,7 +28,7 @@ module CypressRails
         cypress-rails configuration:
         ============================
          CYPRESS_RAILS_DIR.....................#{rails_dir.inspect}
-         CYPRESS_DIR...........................#{cypress_dir.inspect}
+         CYPRESS_RAILS_CYPRESS_DIR.............#{cypress_dir.inspect}
          CYPRESS_RAILS_HOST....................#{host.inspect}
          CYPRESS_RAILS_PORT....................#{port.inspect}
          CYPRESS_RAILS_BASE_PATH...............#{base_path.inspect}

--- a/lib/cypress-rails/finds_bin.rb
+++ b/lib/cypress-rails/finds_bin.rb
@@ -4,8 +4,8 @@ module CypressRails
   class FindsBin
     LOCAL_PATH = "node_modules/.bin/cypress"
 
-    def call(dir = Dir.pwd)
-      local_path = Pathname.new(dir).join(LOCAL_PATH)
+    def call(cy_dir = Dir.pwd)
+      local_path = Pathname.new(cy_dir).join(LOCAL_PATH)
       if File.exist?(local_path)
         local_path
       else

--- a/lib/cypress-rails/finds_bin.rb
+++ b/lib/cypress-rails/finds_bin.rb
@@ -4,8 +4,8 @@ module CypressRails
   class FindsBin
     LOCAL_PATH = "node_modules/.bin/cypress"
 
-    def call(cy_dir = Dir.pwd)
-      local_path = Pathname.new(cy_dir).join(LOCAL_PATH)
+    def call(cypress_dir = Dir.pwd)
+      local_path = Pathname.new(cypress_dir).join(LOCAL_PATH)
       if File.exist?(local_path)
         local_path
       else

--- a/lib/cypress-rails/init.rb
+++ b/lib/cypress-rails/init.rb
@@ -19,8 +19,8 @@ module CypressRails
       })
     JS
 
-    def call(dir = Dir.pwd)
-      config_path = File.join(dir, "cypress.config.js")
+    def call(cypress_dir = Config.new.cypress_dir)
+      config_path = File.join(cypress_dir, "cypress.config.js")
       if !File.exist?(config_path)
         File.write(config_path, DEFAULT_CONFIG)
         puts "Cypress config initialized in `#{config_path}'"

--- a/lib/cypress-rails/launches_cypress.rb
+++ b/lib/cypress-rails/launches_cypress.rb
@@ -24,12 +24,12 @@ module CypressRails
         port: config.port,
         transactional_server: config.transactional_server
       )
-      bin = @finds_bin.call(config.cy_dir)
+      bin = @finds_bin.call(config.cypress_dir)
 
       set_exit_hooks!(config)
 
       command = <<~EXEC
-        CYPRESS_BASE_URL="http://#{server.host}:#{server.port}#{config.base_path}" "#{bin}" #{command} --project "#{config.cy_dir}" #{config.cypress_cli_opts}
+        CYPRESS_BASE_URL="http://#{server.host}:#{server.port}#{config.base_path}" "#{bin}" #{command} --project "#{config.cypress_dir}" #{config.cypress_cli_opts}
       EXEC
 
       puts "\nLaunching Cypress…\n$ #{command}\n"

--- a/lib/cypress-rails/launches_cypress.rb
+++ b/lib/cypress-rails/launches_cypress.rb
@@ -24,12 +24,12 @@ module CypressRails
         port: config.port,
         transactional_server: config.transactional_server
       )
-      bin = @finds_bin.call(config.dir)
+      bin = @finds_bin.call(config.cy_dir)
 
       set_exit_hooks!(config)
 
       command = <<~EXEC
-        CYPRESS_BASE_URL="http://#{server.host}:#{server.port}#{config.base_path}" "#{bin}" #{command} --project "#{config.dir}" #{config.cypress_cli_opts}
+        CYPRESS_BASE_URL="http://#{server.host}:#{server.port}#{config.base_path}" "#{bin}" #{command} --project "#{config.cy_dir}" #{config.cypress_cli_opts}
       EXEC
 
       puts "\nLaunching Cypress…\n$ #{command}\n"

--- a/script/test
+++ b/script/test
@@ -15,5 +15,7 @@ echo "---> Running tests"
 bundle exec rake
 ./script/test_example_app
 
+bundle exec rake test
+
 echo "---> Job's done!"
 

--- a/test/config_test.rb
+++ b/test/config_test.rb
@@ -1,0 +1,44 @@
+require_relative "test_helper"
+
+class ConfigTest < Minitest::Test
+  def test_that_rails_dir_and_cypress_dir_use_default_directory
+    config = CypressRails::Config.new
+    expected_directory_path = Dir.pwd
+
+    assert_equal(expected_directory_path, config.rails_dir)
+    assert_equal(expected_directory_path, config.cypress_dir)
+  end
+
+  def test_that_rails_dir_and_cypress_dir_can_be_independently_set
+    mock_env(
+      "CYPRESS_RAILS_DIR" => "path/to/cypress-rails",
+      "CYPRESS_RAILS_CYPRESS_DIR" => "path/to/another/cypress/directory"
+    ) do
+      config = CypressRails::Config.new
+
+      assert_equal("path/to/cypress-rails", config.rails_dir)
+      assert_equal("path/to/another/cypress/directory", config.cypress_dir)
+    end
+  end
+
+  def test_that_cypress_dir_uses_same_directory_as_rails_dir_when_not_set
+    mock_env("CYPRESS_RAILS_DIR" => "path/to/cypress-rails") do
+      config = CypressRails::Config.new
+
+      assert_nil(ENV["CYPRESS_RAILS_CYPRESS_DIR"])
+      assert_equal("path/to/cypress-rails", config.cypress_dir)
+    end
+  end
+
+  private
+
+  def mock_env(partial_env_hash)
+    old = ENV.to_hash
+    ENV.update partial_env_hash
+    begin
+      yield
+    ensure
+      ENV.replace old
+    end
+  end
+end


### PR DESCRIPTION
Hi! 

Big `cypress-rails` fan and first time open source contributor here, so please excuse any open source contribution etiquette I'm missing! 

Anyways, my team has a specific use-case that isn't quite covered(_I think_) by the current functionality of this gem, so I went about attempting to add that in and have found that it's working as expected. I'm not sure if others would benefit from the same functionality, but I wanted to put a PR out there to get some feelers.

Essentially, our Rails application serves as the API for a React/Cypress project that exists outside of our Rails directory. So, I needed a way for our external cypress project to be launched via the `cypress-rails` commands. With how the main `CYPRESS_RAILS_DIR` env var is configured, it seems like there's an assumption that the Cypress project also exists within the _same_ directory. So I figured it'd be best to spin up another configurable environment variable that specifies where our Cypress project is located called: `CYPRESS_DIR`.

We'd then use that specific variable to manage the launching of Cypress in the `LaunchesCypress` service. Let me know if this makes sense or if there's anything else I can change!